### PR TITLE
Add support so one can terminate the worker thread

### DIFF
--- a/fatfsWrapper.h
+++ b/fatfsWrapper.h
@@ -17,7 +17,8 @@
 extern "C" {
 #endif
 
-void wf_init (tprio_t priority);
+Thread* wf_init (tprio_t priority);
+void wf_terminate (void);
 
 FRESULT wf_mount (BYTE, FATFS*);                     /* Mount/Unmount a logical drive */
 FRESULT wf_open (FIL*, const TCHAR*, BYTE);          /* Open or create a file */


### PR DESCRIPTION
I added support to terminate the worker thread so one may properly shut down:
- `wf_init()` now returns worker thread pointer, as in normal thread creation
- `wf_terminate()` added to initiate thread termination

An extra action was added to cause the thread to loop, allowing termination using the `while(!chThdShouldTerminate())` method.

Not sure if this is desirable or not.
